### PR TITLE
Add alpha channel property and Change default font size 256

### DIFF
--- a/text-pango.c
+++ b/text-pango.c
@@ -243,7 +243,7 @@ static void pango_source_get_defaults(obs_data_t *settings)
 
 	font = obs_data_create();
 	obs_data_set_default_string(font, "face", DEFAULT_FACE);
-	obs_data_set_default_int(font, "size", 32);
+	obs_data_set_default_int(font, "size", 256);
 	obs_data_set_default_obj(settings, "font", font);
 	obs_data_release(font);
 

--- a/text-pango.c
+++ b/text-pango.c
@@ -307,9 +307,9 @@ static obs_properties_t *pango_source_get_properties(void *unused)
 		obs_module_text("Gradient"));
 	obs_property_set_modified_callback(prop,
 		pango_source_properties_gradient_changed);
-	obs_properties_add_color(props, "color1",
+	obs_properties_add_color_alpha(props, "color1",
 		obs_module_text("Gradient.Color"));
-	obs_properties_add_color(props, "color2",
+	obs_properties_add_color_alpha(props, "color2",
 		obs_module_text("Gradient.Color2"));
 
 	prop = obs_properties_add_list(props, "align",


### PR DESCRIPTION
- Alpha channel is added to the color picker for each color.
- Change default size of text to 256.
<img width="1079" alt="screen_2021-07-07 21 59 20" src="https://user-images.githubusercontent.com/17141779/124764742-3d238000-df70-11eb-8783-44c5e21aeb0a.png">
