### PR TITLE
Reload fontconfig map after loading an external font file

### DIFF
--- a/text-utilities.h
+++ b/text-utilities.h
@@ -36,6 +36,14 @@ static void set_font(struct pango_source *src, PangoLayout *layout) {
 			FcFontSet *font_set = FcFontSetCreate();
 			int count = FcFreeTypeQueryAll(src->font_file, -1, NULL, &count, font_set);
 			if (count > 0 ) {
+#if defined(PANGO_VERSION_CHECK) && PANGO_VERSION_CHECK(1,38,0)
+				// need to explicitly notify newer Pango versions that a new font has been added to the FC map
+				// more info: https://gitlab.gnome.org/GNOME/gtk/-/issues/3886
+				if (PANGO_IS_FC_FONT_MAP(pango_cairo_font_map_get_default())) {
+					blog(LOG_INFO, "[pango] refreshing fontconfig map");
+					pango_fc_font_map_config_changed(PANGO_FC_FONT_MAP(pango_cairo_font_map_get_default()));
+				}
+#endif
 				desc = pango_fc_font_description_from_pattern(font_set->fonts[0], FALSE);
 				if (count > 1) {
 					blog(LOG_INFO, "[pango] Specified file(%s) had more than 1 font", src->font_file);

--- a/text-utilities.h
+++ b/text-utilities.h
@@ -36,13 +36,11 @@ static void set_font(struct pango_source *src, PangoLayout *layout) {
 			FcFontSet *font_set = FcFontSetCreate();
 			int count = FcFreeTypeQueryAll(src->font_file, -1, NULL, &count, font_set);
 			if (count > 0 ) {
-#if defined(PANGO_VERSION_CHECK) && PANGO_VERSION_CHECK(1,38,0)
 				// need to explicitly notify newer Pango versions that a new font has been added to the FC map
 				// more info: https://gitlab.gnome.org/GNOME/gtk/-/issues/3886
 				if (PANGO_IS_FC_FONT_MAP(pango_cairo_font_map_get_default())) {
 					pango_fc_font_map_config_changed(PANGO_FC_FONT_MAP(pango_cairo_font_map_get_default()));
 				}
-#endif
 				desc = pango_fc_font_description_from_pattern(font_set->fonts[0], FALSE);
 				if (count > 1) {
 					blog(LOG_INFO, "[pango] Specified file(%s) had more than 1 font", src->font_file);

--- a/text-utilities.h
+++ b/text-utilities.h
@@ -40,7 +40,6 @@ static void set_font(struct pango_source *src, PangoLayout *layout) {
 				// need to explicitly notify newer Pango versions that a new font has been added to the FC map
 				// more info: https://gitlab.gnome.org/GNOME/gtk/-/issues/3886
 				if (PANGO_IS_FC_FONT_MAP(pango_cairo_font_map_get_default())) {
-					blog(LOG_INFO, "[pango] refreshing fontconfig map");
 					pango_fc_font_map_config_changed(PANGO_FC_FONT_MAP(pango_cairo_font_map_get_default()));
 				}
 #endif


### PR DESCRIPTION
Newer pango versions require explicitly reloading the font map with pango_fc_font_map_config_changed after adding a font with FcConfigAppFontAddFile in order for it to be correctly displayed.

More details: https://gitlab.gnome.org/GNOME/gtk/-/issues/3886